### PR TITLE
Support translations during compilation

### DIFF
--- a/lib/kanta/gettext/repo.ex
+++ b/lib/kanta/gettext/repo.ex
@@ -11,8 +11,6 @@ defmodule Kanta.Gettext.Repo do
   alias Kanta.Utils.Compilation
   alias Kanta.Translations
 
-  require Logger
-
   def init(_) do
     __MODULE__
   end

--- a/lib/kanta/gettext/repo.ex
+++ b/lib/kanta/gettext/repo.ex
@@ -1,4 +1,6 @@
 defmodule Kanta.Gettext.Repo do
+  alias Kanta.Utils.Compilation
+
   alias Kanta.Translations.{
     Context,
     Domain,
@@ -8,7 +10,6 @@ defmodule Kanta.Gettext.Repo do
     SingularTranslation
   }
 
-  alias Kanta.Utils.Compilation
   alias Kanta.Translations
 
   def init(_) do

--- a/lib/kanta/utils/compilation.ex
+++ b/lib/kanta/utils/compilation.ex
@@ -1,0 +1,8 @@
+defmodule Kanta.Utils.Compilation do
+  @moduledoc false
+
+  def compiling? do
+    Code.ensure_loaded?(Code) &&
+      apply(Code, :can_await_module_compilation?, [])
+  end
+end

--- a/lib/kanta/utils/compilation.ex
+++ b/lib/kanta/utils/compilation.ex
@@ -1,6 +1,12 @@
 defmodule Kanta.Utils.Compilation do
   @moduledoc false
 
+  @doc """
+  Returns `true` if it is run during compilation.
+
+  This function is used to handle translation messages during compilation time in macros and module attributes.
+  """
+  @spec compiling?() :: boolean()
   def compiling? do
     Code.ensure_loaded?(Code) &&
       Code.can_await_module_compilation?()

--- a/lib/kanta/utils/compilation.ex
+++ b/lib/kanta/utils/compilation.ex
@@ -3,6 +3,6 @@ defmodule Kanta.Utils.Compilation do
 
   def compiling? do
     Code.ensure_loaded?(Code) &&
-      apply(Code, :can_await_module_compilation?, [])
+      Code.can_await_module_compilation?()
   end
 end


### PR DESCRIPTION
Closes #46

As it runs during compilation we have to define a config for `:gettext`, e.g.:
```elixir
config :gettext, default_locale: "es"
```
Tested with module attributes and macros