### PR TITLE
Parse params and add support for different ID types

### DIFF
--- a/lib/kanta/config.ex
+++ b/lib/kanta/config.ex
@@ -8,7 +8,8 @@ defmodule Kanta.Config do
           repo: module(),
           endpoint: module(),
           plugins: false | [module() | {module() | Keyword.t()}],
-          disable_api_authorization: boolean()
+          disable_api_authorization: boolean(),
+          id_parse_function: mfa() | (term() -> {:ok, term()} | term())
         }
 
   defstruct name: Kanta,
@@ -16,7 +17,8 @@ defmodule Kanta.Config do
             repo: nil,
             endpoint: nil,
             plugins: [],
-            disable_api_authorization: false
+            disable_api_authorization: false,
+            id_parse_function: {Kanta.Utils.ParamParsers, :default_id_parser, 1}
 
   alias Kanta.Validator
 
@@ -79,6 +81,24 @@ defmodule Kanta.Config do
     else
       {:error,
        "expected :disable_api_authorization to be a boolean, got: #{inspect(disable_api_authorization)}"}
+    end
+  end
+
+  defp validate_opt(_opts, {:id_parse_function, {module, function, _arity} = id_parse_function}) do
+    if Code.ensure_loaded?(module) and Kernel.function_exported?(module, function, 1) do
+      :ok
+    else
+      {:error,
+       "expected :id_parse_function to be a function with arity of 1, got: #{inspect(id_parse_function)}"}
+    end
+  end
+
+  defp validate_opt(_opts, {:id_parse_function, id_parse_function}) do
+    if is_function(id_parse_function, 1) do
+      :ok
+    else
+      {:error,
+       "expected :id_parse_function to be a function with arity of 1, got: #{inspect(id_parse_function)}"}
     end
   end
 

--- a/lib/kanta/config.ex
+++ b/lib/kanta/config.ex
@@ -84,13 +84,18 @@ defmodule Kanta.Config do
     end
   end
 
-  defp validate_opt(_opts, {:id_parse_function, {module, function, _arity} = id_parse_function}) do
+  defp validate_opt(_opts, {:id_parse_function, {module, function, 1} = id_parse_function}) do
     if Code.ensure_loaded?(module) and Kernel.function_exported?(module, function, 1) do
       :ok
     else
       {:error,
        "expected :id_parse_function to be a function with arity of 1, got: #{inspect(id_parse_function)}"}
     end
+  end
+
+  defp validate_opt(_opts, {:id_parse_function, {_module, _function, _arity} = id_parse_function}) do
+    {:error,
+     "expected :id_parse_function to be a function with arity of 1, got: #{inspect(id_parse_function)}"}
   end
 
   defp validate_opt(_opts, {:id_parse_function, id_parse_function}) do

--- a/lib/kanta/schema.ex
+++ b/lib/kanta/schema.ex
@@ -1,0 +1,13 @@
+defmodule Kanta.Schema do
+  @moduledoc false
+
+  defmacro __using__(_opts) do
+    quote do
+      use Ecto.Schema
+
+      @primary_key {:id, Application.compile_env(:kanta, :schema_id_type, :id),
+                    autogenerate: true}
+      @foreign_key_type Application.compile_env(:kanta, :schema_id_type, :id)
+    end
+  end
+end

--- a/lib/kanta/translations/context.ex
+++ b/lib/kanta/translations/context.ex
@@ -3,7 +3,7 @@ defmodule Kanta.Translations.Context do
   Gettext Context DB model
   """
 
-  use Ecto.Schema
+  use Kanta.Schema
   import Ecto.Changeset
 
   alias Kanta.Translations.Message

--- a/lib/kanta/translations/domain.ex
+++ b/lib/kanta/translations/domain.ex
@@ -3,7 +3,7 @@ defmodule Kanta.Translations.Domain do
   Gettext domain DB model
   """
 
-  use Ecto.Schema
+  use Kanta.Schema
   import Ecto.Changeset
 
   alias Kanta.Translations.Message

--- a/lib/kanta/translations/locale.ex
+++ b/lib/kanta/translations/locale.ex
@@ -3,7 +3,7 @@ defmodule Kanta.Translations.Locale do
   Locale DB model
   """
 
-  use Ecto.Schema
+  use Kanta.Schema
   import Ecto.Changeset
   alias Kanta.Translations.SingularTranslation
 

--- a/lib/kanta/translations/message.ex
+++ b/lib/kanta/translations/message.ex
@@ -3,7 +3,7 @@ defmodule Kanta.Translations.Message do
   Gettext message DB model
   """
 
-  use Ecto.Schema
+  use Kanta.Schema
   import Ecto.Changeset
 
   alias Kanta.Translations.{Context, Domain, PluralTranslation, SingularTranslation}

--- a/lib/kanta/translations/plural_translation.ex
+++ b/lib/kanta/translations/plural_translation.ex
@@ -3,7 +3,7 @@ defmodule Kanta.Translations.PluralTranslation do
   Plural translation DB model
   """
 
-  use Ecto.Schema
+  use Kanta.Schema
   import Ecto.Changeset
 
   alias Kanta.Translations.{Locale, Message}

--- a/lib/kanta/translations/singular_translation.ex
+++ b/lib/kanta/translations/singular_translation.ex
@@ -3,7 +3,7 @@ defmodule Kanta.Translations.SingularTranslation do
   Singular translation DB model
   """
 
-  use Ecto.Schema
+  use Kanta.Schema
   import Ecto.Changeset
   alias Kanta.Translations.{Locale, Message}
 

--- a/lib/kanta/utils/param_parsers.ex
+++ b/lib/kanta/utils/param_parsers.ex
@@ -26,8 +26,4 @@ defmodule Kanta.Utils.ParamParsers do
   defp run_parse_function({module, parse_function, 1}, id) do
     apply(module, parse_function, [id])
   end
-
-  defp run_parse_function(_, _) do
-    raise "Invalid id_parse_function provided in Kanta's config"
-  end
 end

--- a/lib/kanta/utils/param_parsers.ex
+++ b/lib/kanta/utils/param_parsers.ex
@@ -1,6 +1,13 @@
 defmodule Kanta.Utils.ParamParsers do
   @moduledoc false
 
+  def default_id_parser(id) do
+    case Integer.parse(id) do
+      {id, _} -> {:ok, id}
+      _ -> :error
+    end
+  end
+
   def parse_page(page) do
     case Integer.parse(page) do
       {page, _} -> page
@@ -9,9 +16,18 @@ defmodule Kanta.Utils.ParamParsers do
   end
 
   def parse_id_filter(id) do
-    case Integer.parse(id) do
-      {id, _} -> id
-      _ -> nil
-    end
+    run_parse_function(Kanta.config().id_parse_function, id)
+  end
+
+  defp run_parse_function(parse_function, id) when is_function(parse_function, 1) do
+    parse_function.(id)
+  end
+
+  defp run_parse_function({module, parse_function, 1}, id) do
+    apply(module, parse_function, [id])
+  end
+
+  defp run_parse_function(_, _) do
+    raise "Invalid id_parse_function provided in Kanta's config"
   end
 end

--- a/lib/kanta/utils/param_parsers.ex
+++ b/lib/kanta/utils/param_parsers.ex
@@ -1,0 +1,17 @@
+defmodule Kanta.Utils.ParamParsers do
+  @moduledoc false
+
+  def parse_page(page) do
+    case Integer.parse(page) do
+      {page, _} -> page
+      _ -> 1
+    end
+  end
+
+  def parse_id_filter(id) do
+    case Integer.parse(id) do
+      {id, _} -> id
+      _ -> nil
+    end
+  end
+end

--- a/lib/kanta_web/components/shared/select/select.ex
+++ b/lib/kanta_web/components/shared/select/select.ex
@@ -15,7 +15,8 @@ defmodule KantaWeb.Components.Shared.Select do
         if is_nil(field) do
           List.first(options)
         else
-          Enum.find(options, &(&1.value == value_to_integer(field.value))) || List.first(options)
+          Enum.find(options, &(parse_select_value(&1.value) == field.value)) ||
+            List.first(options)
         end
       else
         assigns.selected_option
@@ -40,12 +41,7 @@ defmodule KantaWeb.Components.Shared.Select do
     }
   end
 
-  defp value_to_integer(nil), do: nil
-  defp value_to_integer(""), do: nil
-
-  defp value_to_integer(value) do
-    String.to_integer(value)
-  rescue
-    _ in ArgumentError -> nil
-  end
+  defp parse_select_value(nil), do: nil
+  defp parse_select_value(""), do: nil
+  defp parse_select_value(value), do: to_string(value)
 end

--- a/lib/kanta_web/components/shared/select/select.html.heex
+++ b/lib/kanta_web/components/shared/select/select.html.heex
@@ -1,7 +1,7 @@
 <div
   id={"#{@id}-wrapper"}
   phx-hook="Select"
-  x-data={"{ open: false, idx: -1, selectedIdx: #{Enum.find_index(@options, & &1.value == @field.value or &1.value == value_to_integer(@field.value)) || 0}, max: #{length(@options) - 1} }"}
+  x-data={"{ open: false, idx: -1, selectedIdx: #{Enum.find_index(@options, & parse_select_value(&1.value) == @field.value) || 0}, max: #{length(@options) - 1} }"}
   x-init={"() => { $watch('selectedIdx', val => $dispatch('selected-change', { selectedIdx: val, id: '##{@id}' }) ) }"}
   x-on:reset="open = false"
 >

--- a/lib/kanta_web/live/translations/context_live/context_live.ex
+++ b/lib/kanta_web/live/translations/context_live/context_live.ex
@@ -1,18 +1,25 @@
 defmodule KantaWeb.Translations.ContextLive do
   use KantaWeb, :live_view
 
+  import Kanta.Utils.ParamParsers, only: [parse_id_filter: 1]
+
   alias Kanta.Translations
   alias Kanta.Translations.Context
 
   def mount(%{"id" => id}, _session, socket) do
-    context =
-      case Translations.get_context(filter: [id: id]) do
-        {:ok, %Context{} = context} -> context
-        {:error, _, _reason} -> nil
+    socket =
+      case get_context(id) do
+        {:ok, %Context{} = context} -> assign(socket, :context, context)
+        {:error, _, _reason} -> redirect(socket, to: "/kanta/contexts")
       end
 
-    socket = socket |> assign(:context, context)
-
     {:ok, socket}
+  end
+
+  defp get_context(id) do
+    case parse_id_filter(id) do
+      {:ok, id} -> Translations.get_context(filter: [id: id])
+      _ -> {:error, :id, :invalid}
+    end
   end
 end

--- a/lib/kanta_web/live/translations/domain_live/domain_live.ex
+++ b/lib/kanta_web/live/translations/domain_live/domain_live.ex
@@ -18,8 +18,8 @@ defmodule KantaWeb.Translations.DomainLive do
 
   defp get_domain(id) do
     case parse_id_filter(id) do
-      nil -> {:error, :id, :invalid}
-      id -> Translations.get_domain(filter: [id: id])
+      {:ok, id} -> Translations.get_domain(filter: [id: id])
+      _ -> {:error, :id, :invalid}
     end
   end
 end

--- a/lib/kanta_web/live/translations/domain_live/domain_live.ex
+++ b/lib/kanta_web/live/translations/domain_live/domain_live.ex
@@ -1,18 +1,25 @@
 defmodule KantaWeb.Translations.DomainLive do
   use KantaWeb, :live_view
 
+  import Kanta.Utils.ParamParsers, only: [parse_id_filter: 1]
+
   alias Kanta.Translations
   alias Kanta.Translations.Domain
 
   def mount(%{"id" => id}, _session, socket) do
-    domain =
-      case Translations.get_domain(filter: [id: id]) do
-        {:ok, %Domain{} = domain} -> domain
-        {:error, _, _reason} -> nil
+    socket =
+      case get_domain(id) do
+        {:ok, %Domain{} = domain} -> assign(socket, :domain, domain)
+        {:error, _, _reason} -> redirect(socket, to: "/kanta/domains")
       end
 
-    socket = socket |> assign(:domain, domain)
-
     {:ok, socket}
+  end
+
+  defp get_domain(id) do
+    case parse_id_filter(id) do
+      nil -> {:error, :id, :invalid}
+      id -> Translations.get_domain(filter: [id: id])
+    end
   end
 end

--- a/lib/kanta_web/live/translations/translation_form_live/translation_form_live.ex
+++ b/lib/kanta_web/live/translations/translation_form_live/translation_form_live.ex
@@ -123,15 +123,15 @@ defmodule KantaWeb.Translations.TranslationFormLive do
 
   defp get_locale(locale_id) do
     case parse_id_filter(locale_id) do
-      nil -> nil
-      id -> Translations.get_locale(filter: [id: id])
+      {:ok, id} -> Translations.get_locale(filter: [id: id])
+      _ -> {:error, :id, :invalid}
     end
   end
 
   defp get_message(message_id) do
     case parse_id_filter(message_id) do
-      nil -> nil
-      id -> Translations.get_message(filter: [id: id])
+      {:ok, id} -> Translations.get_message(filter: [id: id])
+      _ -> {:error, :id, :invalid}
     end
   end
 end

--- a/lib/kanta_web/live/translations/translation_form_live/translation_form_live.ex
+++ b/lib/kanta_web/live/translations/translation_form_live/translation_form_live.ex
@@ -1,6 +1,8 @@
 defmodule KantaWeb.Translations.TranslationFormLive do
   use KantaWeb, :live_view
 
+  import Kanta.Utils.ParamParsers, only: [parse_id_filter: 1]
+
   alias Kanta.Translations
   alias Kanta.Translations.Message
 
@@ -41,13 +43,15 @@ defmodule KantaWeb.Translations.TranslationFormLive do
 
   def mount(%{"message_id" => message_id, "locale_id" => locale_id}, _session, socket) do
     socket =
-      with {:ok, locale} <- Translations.get_locale(filter: [id: locale_id]),
-           {:ok, message} <- Translations.get_message(filter: [id: message_id]),
+      with {:ok, locale} <- get_locale(locale_id),
+           {:ok, message} <- get_message(message_id),
            {:ok, translations} <- get_translations(message, locale) do
         socket
         |> assign(:locale, locale)
         |> assign(:message, message)
         |> assign(:translations, translations)
+      else
+        _ -> redirect(socket, to: "/kanta/locales/#{locale_id}/translations")
       end
 
     {:ok, socket}
@@ -114,6 +118,20 @@ defmodule KantaWeb.Translations.TranslationFormLive do
             |> Enum.reject(&is_nil/1)
           }
         end
+    end
+  end
+
+  defp get_locale(locale_id) do
+    case parse_id_filter(locale_id) do
+      nil -> nil
+      id -> Translations.get_locale(filter: [id: id])
+    end
+  end
+
+  defp get_message(message_id) do
+    case parse_id_filter(message_id) do
+      nil -> nil
+      id -> Translations.get_message(filter: [id: id])
     end
   end
 end

--- a/lib/kanta_web/live/translations/translations_live/translations_live.ex
+++ b/lib/kanta_web/live/translations/translations_live/translations_live.ex
@@ -107,28 +107,21 @@ defmodule KantaWeb.Translations.TranslationsLive do
     filters
     |> Map.take(@available_filters)
     |> Enum.reject(fn {_, value} -> is_nil(value) or value == "" end)
-    |> Enum.reduce([filter: %{}, search: "", page: "1"], fn {key, value}, acc ->
-      case key do
-        "search" ->
-          Keyword.put(acc, :search, value)
+    |> Enum.reduce([filter: %{}, search: "", page: "1"], &update_filters_acc/2)
+  end
 
-        "page" ->
-          Keyword.put(acc, :page, value)
+  defp update_filters_acc({"search", value}, acc), do: Keyword.put(acc, :search, value)
+  defp update_filters_acc({"page", value}, acc), do: Keyword.put(acc, :page, value)
 
-        "not_translated" ->
-          Keyword.put(
-            acc,
-            :filter,
-            Map.put(acc[:filter] || %{}, "not_translated", value)
-          )
+  defp update_filters_acc({"not_translated", value}, acc) do
+    Keyword.put(acc, :filter, Map.put(acc[:filter] || %{}, "not_translated", value))
+  end
 
-        filter_key ->
-          case parse_id_filter(value) do
-            {:ok, id} -> Keyword.put(acc, :filter, Map.put(acc[:filter] || %{}, filter_key, id))
-            _ -> acc
-          end
-      end
-    end)
+  defp update_filters_acc({key, value}, acc) do
+    case parse_id_filter(value) do
+      {:ok, id} -> Keyword.put(acc, :filter, Map.put(acc[:filter] || %{}, key, id))
+      _ -> acc
+    end
   end
 
   defp get_assigns_from_params(params) do

--- a/lib/kanta_web/live/translations/translations_live/translations_live.ex
+++ b/lib/kanta_web/live/translations/translations_live/translations_live.ex
@@ -11,6 +11,7 @@ defmodule KantaWeb.Translations.TranslationsLive do
   @available_filters ~w(domain_id context_id search not_translated page)
   @available_params ~w(page search filter)
   @params_in_filter ~w(domain_id context_id not_translated)
+  @ids_to_parse ~w(domain_id context_id locale_id)
 
   def mount(%{"locale_id" => locale_id} = params, _session, socket) do
     socket =
@@ -161,17 +162,17 @@ defmodule KantaWeb.Translations.TranslationsLive do
   defp get_not_translated_default_value(_), do: false
 
   defp parse_filters(filters) do
-    Enum.reduce(filters, %{}, fn {key, value}, acc ->
-      case key do
-        filter_key when filter_key in ["context_id", "domain_id", "locale_id"] ->
-          case parse_id_filter(value) do
-            {:ok, id} -> Map.put(acc, filter_key, id)
-            _ -> acc
-          end
+    Enum.reduce(filters, %{}, &parse_filter/2)
+  end
 
-        filter_key ->
-          Map.put(acc, filter_key, value)
-      end
-    end)
+  defp parse_filter({key, value}, acc) when key in @ids_to_parse do
+    case parse_id_filter(value) do
+      {:ok, id} -> Map.put(acc, key, id)
+      _ -> acc
+    end
+  end
+
+  defp parse_filter({key, value}, acc) do
+    Map.put(acc, key, value)
   end
 end


### PR DESCRIPTION
Closes #50

Migrations have to be configured using `migration_primary_key`
https://hexdocs.pm/ecto_sql/Ecto.Migration.html#module-migrations-configuration

To configure the ID parser use `id_parse_function`, provide MFA to a function or a function that returns `{:ok, id} | term()`. The function has to be of 1 arity.
To configure schema: `config :kanta, schema_id_type: :binary_id`, `config :kanta, schema_id_type: Ecto.ULID`, etc.