### PR TITLE
Make configurable kanta adapters

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -4,7 +4,9 @@ config :kanta, Kanta.Cache,
   primary: [
     gc_interval: :timer.hours(24),
     backend: :shards
-  ]
+  ],
+  adapter: Nebulex.Adapters.Partitioned,
+  primary_storage_adapter: Nebulex.Adapters.Local
 
 config :phoenix, :json_library, Jason
 config :phoenix, :stacktrace_depth, 20

--- a/lib/kanta/cache.ex
+++ b/lib/kanta/cache.ex
@@ -5,8 +5,9 @@ defmodule Kanta.Cache do
 
   use Nebulex.Cache,
     otp_app: :kanta,
-    adapter: Nebulex.Adapters.Partitioned,
-    primary_storage_adapter: Nebulex.Adapters.Local
+    adapter: Application.compile_env(:kanta, :adaptor, Nebulex.Adapters.Partitioned),
+    primary_storage_adapter:
+      Application.compile_env(:kanta, :primary_storage_adapter, Nebulex.Adapters.Local)
 
   def generate_cache_key(prefix, params) do
     Enum.reduce(params, prefix, fn {key, value}, acc ->


### PR DESCRIPTION
# Summary

Make injectable `Kanta.Cache` adapter, primary_storage_adapter from config.exs

# Overview

As described in this issue,
https://github.com/curiosum-dev/kanta/issues/55

when I deploy apps in multi-region on fly.io, Kanta's cache logic causes a huge delay.
and finally, I found that Kanta's cache logic, especially `Nebulex.Cache.Partitioned` causes delay. if we update here [not to use Partitioned cache](https://github.com/eventincgroup/kanta/tree/v0.3.1-localcache), delay was resolved.

This PR is for configurable Kanta's cache logic from config.exs .

