### PR TITLE
Fix arabic plurals bug

### DIFF
--- a/lib/kanta_web/live/translations/translation_form_live/components/plural_translation_form/plural_translation_form.ex
+++ b/lib/kanta_web/live/translations/translation_form_live/components/plural_translation_form/plural_translation_form.ex
@@ -72,7 +72,7 @@ defmodule KantaWeb.Translations.PluralTranslationForm do
   def plural_examples(locale, index) do
     forms_struct = Expo.PluralForms.parse!(locale.plurals_header)
 
-    Enum.group_by(0..30, &Expo.PluralForms.index(forms_struct, &1), & &1)
+    Enum.group_by(0..100, &Expo.PluralForms.index(forms_struct, &1), & &1)
     |> Map.fetch!(index)
     |> Enum.join(", ")
   end


### PR DESCRIPTION
Before this change:

![image](https://github.com/user-attachments/assets/d73aa785-8911-4adf-bd2b-bb8f2edd8f1b)

Clicking "Form 6" would result in this error:

```
[error] GenServer #PID<0.1773.0> terminating
** (KeyError) key 5 not found in: %{
  0 => [0],
  1 => [1],
  2 => [2],
  3 => [3, 4, 5, 6, 7, 8, 9, 10],
  4 => [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
   29, 30]
}
    (erts 15.0.1) :erlang.map_get(5, %{0 => [0], 1 => [1], 2 => [2], 3 => [3, 4, 5, 6, 7, 8, 9, 10], 4 => [11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30]})
    (kanta 0.3.1) lib/kanta_web/live/translations/translation_form_live/components/plural_translation_form/plural_translation_form.ex:76: KantaWeb.Translations.PluralTranslationForm.plural_examples/2
    (kanta 0.3.1) lib/kanta_web/live/translations/translation_form_live/components/plural_translation_form/plural_translation_form.html.heex:46: anonymous fn/2 in KantaWeb.Translations.PluralTranslationForm.render/1
```

It appears that Arabic has a lot of plural variations. Increasing the plural example count from 30 to 100 fixes this problem.