### PR TITLE
Update v03.ex to make it idempotent

### DIFF
--- a/lib/kanta/migrations/postgresql/v03.ex
+++ b/lib/kanta/migrations/postgresql/v03.ex
@@ -43,7 +43,9 @@ defmodule Kanta.Migrations.Postgresql.V03 do
 
   def up_kanta_messages(_opts) do
     alter table(@kanta_messages) do
-      add(:application_source_id, references(@kanta_application_sources), null: true)
+      add_if_not_exists(:application_source_id, references(@kanta_application_sources),
+        null: true
+      )
     end
 
     drop unique_index(@kanta_messages, [:context_id, :domain_id, :msgid])
@@ -75,7 +77,7 @@ defmodule Kanta.Migrations.Postgresql.V03 do
     create_if_not_exists unique_index(@kanta_messages, [:context_id, :domain_id, :msgid])
 
     alter table(@kanta_messages) do
-      remove(:application_source_id)
+      remove_if_exists(:application_source_id)
     end
   end
 end


### PR DESCRIPTION
to prevent following error

```
** (Postgrex.Error) ERROR 42701 (duplicate_column) column "application_source_id" of relation "kanta_messages" already exists
    (ecto_sql 3.12.1) lib/ecto/adapters/sql.ex:1096: Ecto.Adapters.SQL.raise_sql_call_error/1
    (elixir 1.[17](https://github.com/eventincgroup/nexus/actions/runs/11628623080/job/32384101047#step:13:18).1) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
    (ecto_sql 3.12.1) lib/ecto/adapters/sql.ex:1203: Ecto.Adapters.SQL.execute_ddl/4
    (ecto_sql 3.12.1) lib/ecto/migration/runner.ex:348: Ecto.Migration.Runner.log_and_execute_ddl/3
    (elixir 1.17.1) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
    (elixir 1.17.1) lib/enum.ex:1703: Enum."-map/2-lists^map/1-1-"/2
    (ecto_sql 3.12.1) lib/ecto/migration/runner.ex:311: Ecto.Migration.Runner.perform_operation/3
    (stdlib 5.2.3.2) timer.erl:270: :timer.tc/2
```