### PR TITLE
Preload context for DeepL and improve cache encoding

### DIFF
--- a/lib/kanta/cache.ex
+++ b/lib/kanta/cache.ex
@@ -18,7 +18,13 @@ defmodule Kanta.Cache do
           # this old way is just broken for preloads lists
           # encoded_list = (Enum.into(val, %{}) |> URI.encode_query())
           # the new way is robust and reversible
-          encoded_list = val |> :erlang.term_to_binary() |> URI.encode() |> then(&%{encoded_params: &1}) |>  URI.encode_query()
+          encoded_list =
+            val
+            |> :erlang.term_to_binary()
+            |> URI.encode()
+            |> then(&%{encoded_params: &1})
+            |> URI.encode_query()
+
           acc <> "_" <> to_string(key) <> "_" <> encoded_list
 
         _val ->

--- a/lib/kanta/cache.ex
+++ b/lib/kanta/cache.ex
@@ -15,7 +15,11 @@ defmodule Kanta.Cache do
           acc <> "_" <> to_string(key) <> "_" <> URI.encode_query(val)
 
         val when is_list(val) ->
-          acc <> "_" <> to_string(key) <> "_" <> (Enum.into(val, %{}) |> URI.encode_query())
+          # this old way is just broken for preloads lists
+          # encoded_list = (Enum.into(val, %{}) |> URI.encode_query())
+          # the new way is robust and reversible
+          encoded_list = val |> :erlang.term_to_binary() |> URI.encode() |> then(&%{encoded_params: &1}) |>  URI.encode_query()
+          acc <> "_" <> to_string(key) <> "_" <> encoded_list
 
         _val ->
           acc

--- a/lib/kanta_web/live/translations/translation_form_live/translation_form_live.ex
+++ b/lib/kanta_web/live/translations/translation_form_live/translation_form_live.ex
@@ -132,7 +132,7 @@ defmodule KantaWeb.Translations.TranslationFormLive do
 
   defp get_message(message_id) do
     case parse_id_filter(message_id) do
-      {:ok, id} -> Translations.get_message(filter: [id: id])
+      {:ok, id} -> Translations.get_message(filter: [id: id], preloads: [:context])
       _ -> {:error, :id, :invalid}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule Kanta.MixProject do
       {:ecto_sql, "~> 3.12"},
       {:phoenix, "~> 1.7.0"},
       {:phoenix_view, "~> 2.0"},
-      {:phoenix_live_view, "~> 0.20"},
+      {:phoenix_live_view, ">= 0.20.0"},
       {:phoenix_html, "~> 4.0"},
       {:phoenix_html_helpers, "~> 1.0"},
       {:tailwind, "~> 0.2", runtime: Mix.env() == :dev},


### PR DESCRIPTION
Affords fix for https://github.com/curiosum-dev/kanta_deep_l_plugin/issues/6

Necessary for https://github.com/curiosum-dev/kanta_deep_l_plugin/pull/7 to work.