### PR TITLE
Prevent message extractor from crash and log warning on obsolete migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ If you're working on an Elixir/Phoenix project and need to manage translations, 
 - Elixir (tested on 1.14.0)
 - Phoenix (tested on 1.7.0)
 - Ecto SQL (tested on 3.6)
-- PostgreSQL 15 or newer
+- PostgreSQL 15+ or SQLite 3.31.0+
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ If you're working on an Elixir/Phoenix project and need to manage translations, 
 - Elixir (tested on 1.14.0)
 - Phoenix (tested on 1.7.0)
 - Ecto SQL (tested on 3.6)
+- PostgreSQL 15 or newer
 
 ## Installation
 
@@ -181,9 +182,9 @@ In the `application.ex` file of our project, we add Kanta and its configuration 
 
 ## Kanta UI
 
-Inside your `router.ex` file we need to connect the Kanta panel using the kanta_dashboard macro. 
+Inside your `router.ex` file we need to connect the Kanta panel using the kanta_dashboard macro.
 
-```elixir 
+```elixir
 import KantaWeb.Router
 
 scope "/" do
@@ -227,7 +228,7 @@ Not all of us are polyglots, and sometimes we need the help of machine translati
 
 ```elixir
 # mix.exs
-defp deps do 
+defp deps do
   ...
   {:kanta_deep_l_plugin, "~> 0.1.1"}
 end
@@ -242,27 +243,27 @@ config :kanta,
   ]
 ```
 
-## KantaSync 
+## KantaSync
 
 The [KantaSync plugin](https://github.com/curiosum-dev/kanta_sync_plugin) allows you to synchronize translations between your production and staging/dev environments. It ensures that any changes made to translations in one are reflected in the others, helping you maintain consistency across different stages of development.
 
-```elixir 
-# mix.exs 
-defp deps do 
+```elixir
+# mix.exs
+defp deps do
   ...
   {:kanta_sync_plugin, "~> 0.1.0"}
 end
 ```
 
-You need to have Kanta API configured by using kanta_api macro. 
+You need to have Kanta API configured by using kanta_api macro.
 
 ```elixir
-# router.ex 
+# router.ex
 import KantaWeb.Router
 
-scope "/" do 
+scope "/" do
   kanta_api("/kanta-api")
-end 
+end
 ```
 
 ### Authorization

--- a/lib/kanta.ex
+++ b/lib/kanta.ex
@@ -23,6 +23,7 @@ defmodule Kanta do
   @impl Supervisor
   def init(%Config{plugins: plugins} = conf) do
     children = [
+      {Kanta.MigrationVersionChecker, []},
       {MessagesExtractorAgent, conf: conf, name: Registry.via(conf.name, MessagesExtractorAgent)}
     ]
 

--- a/lib/kanta/migration_version_checker.ex
+++ b/lib/kanta/migration_version_checker.ex
@@ -1,0 +1,88 @@
+defmodule Kanta.MigrationVersionChecker do
+  @moduledoc """
+  GenServer responsible for checking if a new migration version is available for Kanta.
+
+  This module runs a version check when started to compare the current database migration
+  version against the latest available version. If a newer version is available, it displays
+  a formatted warning message in the console with:
+
+  - Current and latest version numbers
+  - Step-by-step instructions for updating
+  - Commands to generate and run the required migrations
+
+  The checker supports both PostgreSQL and SQLite3 databases and automatically detects
+  which adapter is being used.
+  """
+
+  use GenServer
+
+  @colors [
+    warning: :yellow,
+    highlight: :cyan,
+    brand: :magenta,
+    reset: :reset
+  ]
+
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @impl true
+  def init(_) do
+    check_version()
+
+    {:ok, %{}}
+  end
+
+  defp check_version do
+    migrator =
+      case Kanta.Repo.get_adapter_name() do
+        :postgres -> Kanta.Migrations.Postgresql
+        :sqlite -> Kanta.Migrations.SQLite3
+      end
+
+    latest_version = migrator.current_version()
+    migrated = migrator.migrated_version(%{repo: Kanta.Repo.get_repo()})
+
+    if migrated < latest_version do
+      warning_message = """
+      #{colorize("⚠️  [Kanta Migration Alert]", @colors[:warning])}
+      #{colorize("━━━━━━━━━━━━━━━━━━━━━━━━━━", @colors[:brand])}
+
+      A new version of Kanta migrations is available for your database!
+
+      Current version: #{colorize(to_string(migrated), @colors[:highlight])}
+      Latest version: #{colorize(to_string(latest_version), @colors[:highlight])}
+
+      To ensure optimal performance and functionality, please update your database schema.
+
+      📝 Here's what you need to do:
+
+      1. Generate a new migration:
+         #{colorize("$ mix ecto.gen.migration update_kanta_migrations", @colors[:brand])}
+
+      2. Add the following to your migration file:
+         #{colorize("def up do", @colors[:highlight])}
+           #{colorize("Kanta.Migration.up(version: #{latest_version})", @colors[:highlight])}
+         #{colorize("end", @colors[:highlight])}
+
+         #{colorize("def down do", @colors[:highlight])}
+           #{colorize("Kanta.Migration.down(version: #{latest_version})", @colors[:highlight])}
+         #{colorize("end", @colors[:highlight])}
+
+      3. Run the migration:
+         #{colorize("$ mix ecto.migrate", @colors[:brand])}
+
+      📚 For more details, visit the Kanta documentation.
+      #{colorize("━━━━━━━━━━━━━━━━━━━━━━━━━━", @colors[:brand])}
+      """
+
+      IO.puts(warning_message)
+    end
+  end
+
+  defp colorize(text, color) do
+    IO.ANSI.format([color, text, @colors[:reset]])
+    |> IO.chardata_to_string()
+  end
+end

--- a/lib/kanta/po_files/messages_extractor_agent.ex
+++ b/lib/kanta/po_files/messages_extractor_agent.ex
@@ -12,8 +12,26 @@ defmodule Kanta.POFiles.MessagesExtractorAgent do
 
   @impl true
   def init(_) do
-    MessagesExtractor.call()
+    if message_extractor_available?() do
+      MessagesExtractor.call()
+    end
 
     {:ok, %{}}
+  end
+
+  defp message_extractor_available? do
+    # Message extractor requires columns added in version 3 of Postgres migration and version 2 of SQLite migration.
+    migrator =
+      case Kanta.Repo.get_adapter_name() do
+        :postgres -> Kanta.Migrations.Postgresql
+        :sqlite -> Kanta.Migrations.SQLite3
+      end
+
+    migrated_version = migrator.migrated_version(%{repo: Kanta.Repo.get_repo()})
+
+    case Kanta.Repo.get_adapter_name() do
+      :postgres -> migrated_version >= 3
+      :sqlite -> migrated_version >= 2
+    end
   end
 end

--- a/lib/kanta/repo.ex
+++ b/lib/kanta/repo.ex
@@ -2,4 +2,11 @@ defmodule Kanta.Repo do
   def get_repo do
     Kanta.config().repo
   end
+
+  def get_adapter_name do
+    case get_repo().__adapter__() do
+      Ecto.Adapters.Postgres -> :postgres
+      Ecto.Adapters.SQLite3 -> :sqlite
+    end
+  end
 end


### PR DESCRIPTION
This PR logs warning in the console when it detects that there is a newer migration available. 
It also fixes problem with MessageExtractor module crashing application on PostgreSQL migration version lower than 3 and SQLite3 lower than 2. 