### PR TITLE
Remove obsolete functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ If you're working on an Elixir/Phoenix project and need to manage translations, 
 - Elixir (tested on 1.14.0)
 - Phoenix (tested on 1.7.0)
 - Ecto SQL (tested on 3.6)
+- Phoenix LiveView 0.18.0+
 - PostgreSQL 15+ or SQLite 3.31.0+
 
 ## Installation

--- a/lib/kanta_web/live/translations/application_source_form_live/application_source_form_live.ex
+++ b/lib/kanta_web/live/translations/application_source_form_live/application_source_form_live.ex
@@ -54,7 +54,7 @@ defmodule KantaWeb.Translations.ApplicationSourceFormLive do
     socket =
       case Translations.update_application_source(application_source, attrs) do
         {:ok, _application_source} ->
-          push_redirect(socket, to: dashboard_path(socket, "/application_sources"))
+          push_navigate(socket, to: dashboard_path(socket, "/application_sources"))
 
         {:error, changeset} ->
           assign(socket, :form, to_form(changeset))
@@ -67,7 +67,7 @@ defmodule KantaWeb.Translations.ApplicationSourceFormLive do
     socket =
       case Translations.create_application_source(attrs) do
         {:ok, _application_source} ->
-          push_redirect(socket, to: dashboard_path(socket, "/application_sources"))
+          push_navigate(socket, to: dashboard_path(socket, "/application_sources"))
 
         {:error, changeset} ->
           assign(socket, :form, to_form(changeset))

--- a/lib/kanta_web/live/translations/application_sources_live/application_sources_live.ex
+++ b/lib/kanta_web/live/translations/application_sources_live/application_sources_live.ex
@@ -19,7 +19,7 @@ defmodule KantaWeb.Translations.ApplicationSourcesLive do
   end
 
   def handle_event("navigate", %{"to" => to}, socket) do
-    {:noreply, push_redirect(socket, to: "/kanta" <> to)}
+    {:noreply, push_navigate(socket, to: "/kanta" <> to)}
   end
 
   def handle_event("page_changed", %{"index" => page_number}, socket) do

--- a/lib/kanta_web/live/translations/contexts_live/contexts_live.ex
+++ b/lib/kanta_web/live/translations/contexts_live/contexts_live.ex
@@ -18,7 +18,7 @@ defmodule KantaWeb.Translations.ContextsLive do
   end
 
   def handle_event("navigate", %{"to" => to}, socket) do
-    {:noreply, push_redirect(socket, to: dashboard_path(socket) <> to)}
+    {:noreply, push_navigate(socket, to: dashboard_path(socket) <> to)}
   end
 
   def handle_event("page_changed", %{"index" => page_number}, socket) do

--- a/lib/kanta_web/live/translations/domains_live/domains_live.ex
+++ b/lib/kanta_web/live/translations/domains_live/domains_live.ex
@@ -18,7 +18,7 @@ defmodule KantaWeb.Translations.DomainsLive do
   end
 
   def handle_event("navigate", %{"to" => to}, socket) do
-    {:noreply, push_redirect(socket, to: dashboard_path(socket) <> to)}
+    {:noreply, push_navigate(socket, to: dashboard_path(socket) <> to)}
   end
 
   def handle_event("page_changed", %{"index" => page_number}, socket) do

--- a/lib/kanta_web/live/translations/translation_form_live/components/plural_translation_form/plural_translation_form.ex
+++ b/lib/kanta_web/live/translations/translation_form_live/components/plural_translation_form/plural_translation_form.ex
@@ -63,7 +63,7 @@ defmodule KantaWeb.Translations.PluralTranslationForm do
     })
 
     {:noreply,
-     push_redirect(socket,
+     push_navigate(socket,
        to:
          dashboard_path(socket, "/locales/#{locale.id}/translations" <> get_query(socket.assigns))
      )}

--- a/lib/kanta_web/live/translations/translation_form_live/components/singular_translation_form/singular_translation_form.ex
+++ b/lib/kanta_web/live/translations/translation_form_live/components/singular_translation_form/singular_translation_form.ex
@@ -29,7 +29,7 @@ defmodule KantaWeb.Translations.SingularTranslationForm do
     Translations.update_singular_translation(translation, %{"translated_text" => translated})
 
     {:noreply,
-     push_redirect(socket,
+     push_navigate(socket,
        to:
          dashboard_path(socket, "/locales/#{locale.id}/translations" <> get_query(socket.assigns))
      )}

--- a/lib/kanta_web/live/translations/translations_live/translations_live.ex
+++ b/lib/kanta_web/live/translations/translations_live/translations_live.ex
@@ -79,7 +79,7 @@ defmodule KantaWeb.Translations.TranslationsLive do
   end
 
   def handle_event("navigate", %{"to" => to}, socket) do
-    {:noreply, push_redirect(socket, to: dashboard_path(socket) <> to)}
+    {:noreply, push_navigate(socket, to: dashboard_path(socket) <> to)}
   end
 
   def handle_event("page_changed", %{"index" => page_number}, socket) do


### PR DESCRIPTION
This PR replaces obsolete `push_redirect/2` that throws warnings on Phoenix LiveView 0.18.0+ with `push_navigate/2`. 