### PR TITLE
fix: translated_text in Kanta.Translations.PluralTranslation can be nil

### DIFF
--- a/lib/kanta/backend/adapter/cached_db.ex
+++ b/lib/kanta/backend/adapter/cached_db.ex
@@ -97,7 +97,7 @@ defmodule Kanta.Backend.Adapter.CachedDB do
            ),
          {:ok, plurals_options} <- Expo.PluralForms.parse(plurals_header),
          nplural_index <- Expo.PluralForms.index(plurals_options, n),
-         {:ok, %PluralTranslation{translated_text: text}} <-
+         {:ok, %PluralTranslation{translated_text: text}} when not is_nil(text) <-
            Translations.get_plural_translation(
              filter: [
                locale_id: locale_id,


### PR DESCRIPTION
# Pull Request

## Description

`translated_text` in `Kanta.Translations.PluralTranslation` can be nil
https://github.com/kubosuke/kanta/blob/c090279abc87904c26943744a0ebbe014eeb1c59/lib/kanta/translations/plural_translation.ex#L21-L22

but in the cached_db logic, this case is not being considered, in our app we got this error below:

```
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in Gettext.Interpolation.Default.runtime_interpolate/2
        (gettext 1.0.2) lib/gettext/interpolation/default.ex:101: Gettext.Interpolation.Default.runtime_interpolate(nil, %{count: 2})
        (kanta 0.5.1) lib/kanta/backend/adapter/cached_db.ex:131: Kanta.Backend.Adapter.CachedDB.apply_bindings/2
        (kanta 0.5.1) lib/kanta/backend/adapter/cached_db.ex:108: Kanta.Backend.Adapter.CachedDB.lngettext/7
        (myapp 0.1.0) lib/myapp_web/gettext.ex:23: myappWeb.Gettext."handle_missing_plural_translation (overridable 2)"/7
        (myapp 0.1.0) lib/myapp_web/gettext.ex:153: myappWeb.Gettext.handle_missing_plural_translation/7
        (gettext 1.0.2) lib/gettext.ex:987: Gettext.dpngettext/7
        (myapp 0.1.0) lib/myapp_web/live/listing_live/components/listing.ex:14: anonymous fn/2 in myappWeb.Listing.Components.Listing.render/1
        (phoenix_live_view 1.1.17) lib/phoenix_live_view/diff.ex:420: Phoenix.LiveView.Diff.traverse/6
        (phoenix_live_view 1.1.17) lib/phoenix_live_view/diff.ex:609: anonymous fn/3 in Phoenix.LiveView.Diff.traverse_dynamic/6
        (elixir 1.18.3) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
        (phoenix_live_view 1.1.17) lib/phoenix_live_view/diff.ex:419: Phoenix.LiveView.Diff.traverse/6
        (phoenix_live_view 1.1.17) lib/phoenix_live_view/diff.ex:609: anonymous fn/3 in Phoenix.LiveView.Diff.traverse_dynamic/6
        (elixir 1.18.3) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
        (phoenix_live_view 1.1.17) lib/phoenix_live_view/diff.ex:419: Phoenix.LiveView.Diff.traverse/6
        (phoenix_live_view 1.1.17) lib/phoenix_live_view/diff.ex:146: Phoenix.LiveView.Diff.render/4
        (phoenix_live_view 1.1.17) lib/phoenix_live_view/static.ex:291: Phoenix.LiveView.Static.to_rendered_content_tag/4
        (phoenix_live_view 1.1.17) lib/phoenix_live_view/static.ex:171: Phoenix.LiveView.Static.do_render/4
```

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] CI/CD improvements

## Related Issues

<!-- Link any related issues -->
Fixes #<!-- issue number -->
Closes #<!-- issue number -->
Related to #<!-- issue number -->

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Testing

<!-- Describe the tests you ran to verify your changes -->

### Test Environment
- [ ] Elixir version: <!-- e.g., 1.17.0 -->
- [ ] OTP version: <!-- e.g., 27 -->
- [ ] Phoenix version: <!-- e.g., 1.7.0 -->
- [ ] Database: <!-- e.g., PostgreSQL 14 or SQLite 3 -->
- [ ] Gettext version: <!-- if using custom fork -->

```
Erlang/OTP 28 [erts-16.1] [source] [64-bit] [smp:11:11] [ds:11:11:10] [async-threads:1] [jit]

Elixir 1.19.2 (compiled with Erlang/OTP 26)

❯ mix deps  | grep -e phoenix -e gettext
* gettext 1.0.0 (Hex package) (mix)
  locked at 1.0.0 (gettext) cc819664
* phoenix 1.8.1 (Hex package) (mix)
  locked at 1.8.1 (phoenix) 84d77d2b
* phoenix_html 4.3.0 (Hex package) (mix)
  locked at 4.3.0 (phoenix_html) 3eaa290a
* phoenix_html_helpers 1.0.1 (Hex package) (mix)
  locked at 1.0.1 (phoenix_html_helpers) cffd2385
* phoenix_live_view 1.1.14 (Hex package) (mix)
  locked at 1.1.14 (phoenix_live_view) b827980e
* phoenix_pubsub 2.1.3 (Hex package) (mix)
  locked at 2.1.3 (phoenix_pubsub) bba06bc1
* phoenix_template 1.0.4 (Hex package) (mix)
  locked at 1.0.4 (phoenix_template) 2c0c81f0
* phoenix_view 2.0.4 (Hex package) (mix)
  locked at 2.0.4 (phoenix_view) 4e992022
```

### Test Cases
- [ ] All existing tests pass
- [ ] New tests added for new functionality at appropriate levels
- [ ] Manual testing performed

### Test Commands Run
```bash
# List the commands you ran to test
mix test
MIX_ENV=test mix credo
MIX_ENV=test mix dialyzer
```

## Documentation

- [ ] Updated README.md (if applicable)
- [ ] Updated documentation comments (with examples for new features)
- [ ] Updated CHANGELOG.md (if applicable)

## Code Quality

- [ ] Code follows the existing style conventions
- [ ] Self-review of the code has been performed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [ ] No new linting warnings introduced
- [ ] No new Dialyzer warnings introduced

## Backward Compatibility

- [ ] This change is backward compatible
- [ ] This change includes breaking changes (please describe below)
- [ ] Migration guide provided for breaking changes

### Breaking Changes
<!-- If there are breaking changes, describe them here -->

## Performance Impact

- [ ] No performance impact
- [ ] Performance improvement
- [ ] Potential performance regression (please describe)

### Performance Notes
<!-- Describe any performance considerations -->

## Translation Management Impact

- [ ] No impact on existing translations
- [ ] Affects translation extraction process
- [ ] Affects translation storage/retrieval
- [ ] Affects Kanta UI/dashboard
- [ ] Affects plugin system
- [ ] Database schema changes

### Translation Impact Notes
<!-- Describe how this change affects translation workflows -->

## Security Considerations

- [ ] No security impact
- [ ] Security improvement
- [ ] Potential security impact (please describe)

## Additional Notes

<!-- Any additional information that reviewers should know -->
<!-- For UI changes, please include before/after screenshots -->
<!-- For new plugins, include setup/configuration examples -->

## Screenshots/Examples

<!-- If applicable, add screenshots of UI changes or code examples -->

```elixir
# Example usage of new translation management feature
# For UI changes, show before/after screenshots
# For API changes, show usage example:

# Example: New translation extraction feature
Kanta.extract_translations_from_po_files(domain: "errors")

# Example: New plugin integration
defmodule MyApp.CustomTranslationPlugin do
  use Kanta.Plugin
  # implementation
end
```

## Checklist

- [ ] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Reviewer Notes

<!-- Any specific areas you'd like reviewers to focus on -->

---

<!-- Thank you for contributing to Kanta! -->

```
kanta on  fix/prural-text-nil via  v16.14.2
❯ MIX_ENV=test mix ecto.drop && MIX_ENV=test mix ecto.create && MIX_ENV=test mix ecto.migrate > /dev/null
The database for Kanta.Test.Repo has been dropped
The database for Kanta.Test.Repo has been created

kanta on  fix/prural-text-nil via  v16.14.2
❯ mix test
Running ExUnit with seed: 269084, max_cases: 22

...................................................................................................
Finished in 1.2 seconds (1.0s async, 0.2s sync)
99 tests, 0 failures

kanta on  fix/prural-text-nil via  v16.14.2
❯ elixir -v
Erlang/OTP 28 [erts-16.1] [source] [64-bit] [smp:11:11] [ds:11:11:10] [async-threads:1] [jit]

Elixir 1.19.2 (compiled with Erlang/OTP 26)
```
