### PR TITLE
don't call stale detection on each call and add flag to disable it

### DIFF
--- a/lib/kanta/config.ex
+++ b/lib/kanta/config.ex
@@ -9,6 +9,7 @@ defmodule Kanta.Config do
           endpoint: module(),
           plugins: false | [module() | {module() | Keyword.t()}],
           disable_api_authorization: boolean(),
+          disable_stale_detection: boolean(),
           id_parse_function: mfa() | (term() -> {:ok, term()} | term())
         }
 
@@ -18,6 +19,7 @@ defmodule Kanta.Config do
             endpoint: nil,
             plugins: [],
             disable_api_authorization: false,
+            disable_stale_detection: false,
             id_parse_function: {Kanta.Utils.ParamParsers, :default_id_parser, 1}
 
   alias Kanta.Validator
@@ -81,6 +83,15 @@ defmodule Kanta.Config do
     else
       {:error,
        "expected :disable_api_authorization to be a boolean, got: #{inspect(disable_api_authorization)}"}
+    end
+  end
+
+  defp validate_opt(_opts, {:disable_stale_detection, disable_stale_detection}) do
+    if is_boolean(disable_stale_detection) do
+      :ok
+    else
+      {:error,
+       "expected :disable_stale_detection to be a boolean, got: #{inspect(disable_stale_detection)}"}
     end
   end
 

--- a/lib/kanta/po_files/messages_extractor_agent.ex
+++ b/lib/kanta/po_files/messages_extractor_agent.ex
@@ -12,20 +12,25 @@ defmodule Kanta.PoFiles.MessagesExtractorAgent do
   end
 
   @impl true
-  def init(_) do
-    state =
-      if message_extractor_available?() do
-        {:ok, _messages} = MessagesExtractor.call()
+  def init(conf: %Kanta.Config{disable_stale_detection: true}) do
+    {:ok, %{stale_detection_result: nil}}
+  end
 
-        # Detect stale translations system-wide with fuzzy matching
-        {:ok, %StaleDetection.Result{} = result} = StaleDetection.call()
+  def init(_opts) do
+    {:ok, init_stale_detection()}
+  end
 
-        %{stale_detection_result: result}
-      else
-        %{stale_detection_result: nil}
-      end
+  defp init_stale_detection do
+    if message_extractor_available?() do
+      {:ok, _messages} = MessagesExtractor.call()
 
-    {:ok, state}
+      # Detect stale translations system-wide with fuzzy matching
+      {:ok, %StaleDetection.Result{} = result} = StaleDetection.call()
+
+      %{stale_detection_result: result}
+    else
+      %{stale_detection_result: nil}
+    end
   end
 
   @doc """
@@ -51,9 +56,12 @@ defmodule Kanta.PoFiles.MessagesExtractorAgent do
   end
 
   def handle_call({:get_stale_detection_result, true}, _from, state) do
-    {:ok, %StaleDetection.Result{} = result} = StaleDetection.call()
-
-    {:reply, result, %{state | stale_detection_result: result}}
+    if Kanta.config().disable_stale_detection do
+      {:reply, state.stale_detection_result, state}
+    else
+      {:ok, %StaleDetection.Result{} = result} = StaleDetection.call()
+      {:reply, result, %{state | stale_detection_result: result}}
+    end
   end
 
   defp message_extractor_available? do

--- a/lib/kanta_web/live/dashboard/dashboard_live/dashboard_live.ex
+++ b/lib/kanta_web/live/dashboard/dashboard_live/dashboard_live.ex
@@ -35,33 +35,41 @@ defmodule KantaWeb.Dashboard.DashboardLive do
   end
 
   def handle_event("delete-stale", _, socket) do
-    %Result{stale_message_ids: stale_message_ids} =
-      MessagesExtractorAgent.get_stale_detection_result()
+    if Kanta.config().disable_stale_detection do
+      {:noreply, socket}
+    else
+      %Result{stale_message_ids: stale_message_ids} =
+        MessagesExtractorAgent.get_stale_detection_result()
 
-    Translations.delete_messages(MapSet.to_list(stale_message_ids))
+      Translations.delete_messages(MapSet.to_list(stale_message_ids))
 
-    stale_messages_count =
-      MessagesExtractorAgent.get_stale_detection_result(true).stale_count
+      stale_messages_count =
+        MessagesExtractorAgent.get_stale_detection_result(true).stale_count
 
-    {:noreply, assign(socket, :stale_messages_count, stale_messages_count)}
+      {:noreply, assign(socket, :stale_messages_count, stale_messages_count)}
+    end
   end
 
   # Merge all the orphaned messages to selected target messages (that fuzzy mathed).
   def handle_event("restore-mergeable", _, socket) do
-    %Result{fuzzy_matches_map: fuzzy_matches_map} =
-      MessagesExtractorAgent.get_stale_detection_result()
+    if Kanta.config().disable_stale_detection do
+      {:noreply, socket}
+    else
+      %Result{fuzzy_matches_map: fuzzy_matches_map} =
+        MessagesExtractorAgent.get_stale_detection_result()
 
-    # Merge all messages with fuzzy matches
-    Enum.each(fuzzy_matches_map, fn {_stale_id, fuzzy_match} ->
-      Translations.merge_messages(fuzzy_match.stale_message_id, fuzzy_match.matched_message_id)
-    end)
+      # Merge all messages with fuzzy matches
+      Enum.each(fuzzy_matches_map, fn {_stale_id, fuzzy_match} ->
+        Translations.merge_messages(fuzzy_match.stale_message_id, fuzzy_match.matched_message_id)
+      end)
 
-    result = MessagesExtractorAgent.get_stale_detection_result(true)
+      result = MessagesExtractorAgent.get_stale_detection_result(true)
 
-    {:noreply,
-     socket
-     |> assign(:mergeable_messages_count, result.mergeable_count)
-     |> assign(:stale_messages_count, result.stale_count)}
+      {:noreply,
+       socket
+       |> assign(:mergeable_messages_count, result.mergeable_count)
+       |> assign(:stale_messages_count, result.stale_count)}
+    end
   end
 
   def translation_progress(language) do
@@ -69,16 +77,24 @@ defmodule KantaWeb.Dashboard.DashboardLive do
   end
 
   defp get_stale_messages_count do
-    %Result{stale_count: stale_count} =
-      MessagesExtractorAgent.get_stale_detection_result()
-
-    stale_count
+    if Kanta.config().disable_stale_detection do
+      0
+    else
+      case MessagesExtractorAgent.get_stale_detection_result() do
+        nil -> 0
+        %Result{stale_count: stale_count} -> stale_count
+      end
+    end
   end
 
   defp get_mergeable_messages_count do
-    %Result{mergeable_count: mergeable_count} =
-      MessagesExtractorAgent.get_stale_detection_result()
-
-    mergeable_count
+    if Kanta.config().disable_stale_detection do
+      0
+    else
+      case MessagesExtractorAgent.get_stale_detection_result() do
+        nil -> 0
+        %Result{mergeable_count: mergeable_count} -> mergeable_count
+      end
+    end
   end
 end

--- a/lib/kanta_web/live/translations/translations_live/translations_live.ex
+++ b/lib/kanta_web/live/translations/translations_live/translations_live.ex
@@ -21,15 +21,13 @@ defmodule KantaWeb.Translations.TranslationsLive do
     socket =
       case get_locale(locale_id) do
         {:ok, locale} ->
-          # Get system-wide stale detection with fuzzy matching
-          {:ok, stale_result} =
-            Kanta.PoFiles.Services.StaleDetection.call()
+          {stale_message_ids, fuzzy_matches} = stale_detection_assigns()
 
           socket
           |> assign(:locale, locale)
           |> assign(:application_sources_empty?, Translations.application_sources_empty?())
-          |> assign(:stale_message_ids, stale_result.stale_message_ids)
-          |> assign(:fuzzy_matches, stale_result.fuzzy_matches_map)
+          |> assign(:stale_message_ids, stale_message_ids)
+          |> assign(:fuzzy_matches, fuzzy_matches)
           |> assign(get_assigns_from_params(params))
 
         _ ->
@@ -38,6 +36,17 @@ defmodule KantaWeb.Translations.TranslationsLive do
       end
 
     {:ok, socket}
+  end
+
+  defp stale_detection_assigns do
+    if Kanta.config().disable_stale_detection do
+      {MapSet.new(), %{}}
+    else
+      case MessagesExtractorAgent.get_stale_detection_result() do
+        nil -> {MapSet.new(), %{}}
+        %Result{stale_message_ids: ids, fuzzy_matches_map: fuzzy} -> {ids, fuzzy}
+      end
+    end
   end
 
   def handle_params(%{"locale_id" => locale_id} = params, _location, socket) do
@@ -118,9 +127,15 @@ defmodule KantaWeb.Translations.TranslationsLive do
   def handle_info(:refresh_messages, socket) do
     locale_id = socket.assigns.locale.id
 
-    # Re-detect system-wide stale messages with fuzzy matching
-    %Result{stale_message_ids: stale_message_ids, fuzzy_matches_map: fuzzy_matches_map} =
-      MessagesExtractorAgent.get_stale_detection_result(true)
+    {stale_message_ids, fuzzy_matches_map} =
+      if Kanta.config().disable_stale_detection do
+        {socket.assigns.stale_message_ids, socket.assigns.fuzzy_matches}
+      else
+        case MessagesExtractorAgent.get_stale_detection_result(true) do
+          nil -> {MapSet.new(), %{}}
+          %Result{stale_message_ids: ids, fuzzy_matches_map: fuzzy} -> {ids, fuzzy}
+        end
+      end
 
     # Re-fetch messages with current filters
     preload_filters = %{"locale_id" => locale_id}


### PR DESCRIPTION
# Pull Request

## Description

in short, performance fix around stale detector

Fixes severe performance on the translations list page (`/kanta/locales/:id/translations`) when many messages exist (~22k+). The page was replying in **~45 seconds** because full stale detection (load all messages, PO parsing, partitioning, fuzzy Jaro matching) ran **synchronously on every mount**. This PR uses the **cached** stale-detection result from `MessagesExtractorAgent` on mount instead of calling `StaleDetection.call()` each time, and adds a **config flag** to disable stale detection entirely (no work at boot or on translations/dashboard, 0 counts in UI).

example:

```
[info] GET /kanta/locales/3/translations
[debug] Processing with KantaWeb.Translations.TranslationsLive.__live__/0
  Parameters: %{"locale_id" => "3"}
  Pipelines: [:browser, :domain_basic_auth, :custom_basic_auth]
[debug] QUERY OK db=0.2ms queue=0.2ms idle=1045.2ms
SELECT data, expires_at FROM sessions ...
...
[debug] QUERY OK source="kanta_messages" db=12.4ms decode=0.9ms idle=72.1ms
SELECT k0."id", k0."msgid", ... FROM "kanta_messages" AS k0 []
↳ Kanta.PoFiles.Services.StaleDetection.call/1, at: lib/kanta/po_files/services/stale_detection.ex:97
...
[debug] Replied in 45059ms 👈 45sec to load /locales/foo/translations page!
[debug] HANDLE PARAMS in KantaWeb.Translations.TranslationsLive
...
[debug] Replied in 17ms
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Test improvements
- [ ] CI/CD improvements

## Related Issues

<!-- Link any related issues -->
Fixes #<!-- issue number -->
Closes #<!-- issue number -->
Related to #<!-- issue number -->

## Changes Made

- **TranslationsLive.mount**: Use `MessagesExtractorAgent.get_stale_detection_result()` (cached) instead of `Kanta.PoFiles.Services.StaleDetection.call()`. Handle `nil` (e.g. before agent has run) as empty `stale_message_ids` and `fuzzy_matches`.
- **TranslationsLive**: Add `stale_detection_assigns/0` helper; when `Kanta.config().disable_stale_detection` is true, assign empty MapSet and empty map and skip the agent.
- **TranslationsLive.handle_info(:refresh_messages)**: When stale detection is disabled, skip recomputing and keep current assigns; otherwise keep using `get_stale_detection_result(true)` for refresh-after-merge/delete.
- **Kanta.Config**: New option `disable_stale_detection: boolean()` (default `false`) with validation.
- **MessagesExtractorAgent.init**: When `conf.disable_stale_detection` is true (pattern-matched), skip `MessagesExtractor` and `StaleDetection.call()` and set `stale_detection_result: nil`. When `get_stale_detection_result(true)` is called and disabled, return current state without running StaleDetection.
- **DashboardLive**: When `disable_stale_detection` is true, `get_stale_messages_count` and `get_mergeable_messages_count` return 0 without calling the agent; "delete stale" and "restore mergeable" handlers no-op.

## Testing

### Test Environment
- [ ] Elixir version: <!-- e.g., 1.17.0 -->
- [ ] OTP version: <!-- e.g., 27 -->
- [ ] Phoenix version: <!-- e.g., 1.7.0 -->
- [ ] Database: <!-- e.g., PostgreSQL 14 or SQLite 3 -->
- [ ] Gettext version: <!-- if using custom fork -->

### Test Cases
- [x] All existing tests pass
- [ ] New tests added for new functionality at appropriate levels
- [ ] Manual testing performed

### Test Commands Run
```bash
mix test
# All 99 tests pass
```

## Documentation

- [ ] Updated README.md (if applicable)
- [ ] Updated documentation comments (with examples for new features)
- [ ] Updated CHANGELOG.md (if applicable)

## Code Quality

- [x] Code follows the existing style conventions
- [x] Self-review of the code has been performed
- [ ] Code has been commented, particularly in hard-to-understand areas
- [x] No new linting warnings introduced
- [ ] No new Dialyzer warnings introduced

## Backward Compatibility

- [x] This change is backward compatible
- [ ] This change includes breaking changes (please describe below)
- [ ] Migration guide provided for breaking changes

### Breaking Changes
None.

## Performance Impact

- [x] Performance improvement

### Performance Notes

Before this change, loading `/kanta/locales/3/translations` with ~22,868 translations showed **Replied in 45059ms** while DB queries were fast. Example logs:

```
[info] GET /kanta/locales/3/translations
[debug] Processing with KantaWeb.Translations.TranslationsLive.__live__/0
  Parameters: %{"locale_id" => "3"}
  Pipelines: [:browser, :domain_basic_auth, :custom_basic_auth]
[debug] QUERY OK db=0.2ms queue=0.2ms idle=1045.2ms
SELECT data, expires_at FROM sessions ...
...
[debug] QUERY OK source="kanta_messages" db=12.4ms decode=0.9ms idle=72.1ms
SELECT k0."id", k0."msgid", ... FROM "kanta_messages" AS k0 []
↳ Kanta.PoFiles.Services.StaleDetection.call/1, at: lib/kanta/po_files/services/stale_detection.ex:97
...
[debug] Replied in 45059ms
[debug] HANDLE PARAMS in KantaWeb.Translations.TranslationsLive
...
[debug] Replied in 17ms
```

The bottleneck was **CPU work in StaleDetection** (loading all messages, partitioning, fuzzy Jaro matching), not DB or cache. After the fix, the translations page uses the agent's cached result on mount, so response time should align with the ~17ms observed for `handle_params` after the first reply. With `disable_stale_detection: true`, no StaleDetection runs at boot or on translations/dashboard requests.

## Translation Management Impact

- [x] Affects Kanta UI/dashboard

### Translation Impact Notes

Translations list and dashboard use stale detection for "stale" badges and merge suggestions. With the flag enabled (default), behavior is unchanged except that the list page loads quickly. With `disable_stale_detection: true`, stale/mergeable counts show as 0 and related actions are no-ops.

## Security Considerations

- [x] No security impact

## Additional Notes

Host apps can disable stale detection via Kanta config, e.g. in `config/config.exs`:

```elixir
config :my_app, Kanta,
  endpoint: MyAppWeb.Endpoint,
  repo: MyApp.Repo,
  otp_name: :my_app,
  disable_stale_detection: true
```

Ensure this config is passed to `Kanta.start_link/1` (e.g. via `Application.get_env(:my_app, Kanta, [])`).

## Screenshots/Examples

```elixir
# Disable stale detection (no DB/PO/fuzzy work for stale detection)
config :nexus, Kanta,
  endpoint: NexusWeb.Endpoint,
  repo: Nexus.Repo.Local,
  otp_name: :nexus,
  disable_stale_detection: true
```

## Checklist

- [ ] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Reviewer Notes

- TranslationsLive mount now uses cached stale result + optional disable flag; `handle_info(:refresh_messages)` still recomputes when stale detection is enabled.
- MessagesExtractorAgent init uses pattern match `init(conf: %Kanta.Config{disable_stale_detection: true})` for the disabled path.


