### PR TITLE
fix: disable_stale_detection did not work on agent startup [#55]

### DIFF
--- a/lib/kanta/config.ex
+++ b/lib/kanta/config.ex
@@ -9,6 +9,7 @@ defmodule Kanta.Config do
           endpoint: module(),
           plugins: false | [module() | {module() | Keyword.t()}],
           disable_api_authorization: boolean(),
+          disable_stale_detection: boolean(),
           id_parse_function: mfa() | (term() -> {:ok, term()} | term())
         }
 
@@ -18,6 +19,7 @@ defmodule Kanta.Config do
             endpoint: nil,
             plugins: [],
             disable_api_authorization: false,
+            disable_stale_detection: false,
             id_parse_function: {Kanta.Utils.ParamParsers, :default_id_parser, 1}
 
   alias Kanta.Validator
@@ -81,6 +83,15 @@ defmodule Kanta.Config do
     else
       {:error,
        "expected :disable_api_authorization to be a boolean, got: #{inspect(disable_api_authorization)}"}
+    end
+  end
+
+  defp validate_opt(_opts, {:disable_stale_detection, disable_stale_detection}) do
+    if is_boolean(disable_stale_detection) do
+      :ok
+    else
+      {:error,
+       "expected :disable_stale_detection to be a boolean, got: #{inspect(disable_stale_detection)}"}
     end
   end
 

--- a/lib/kanta/po_files/messages_extractor_agent.ex
+++ b/lib/kanta/po_files/messages_extractor_agent.ex
@@ -12,20 +12,27 @@ defmodule Kanta.PoFiles.MessagesExtractorAgent do
   end
 
   @impl true
-  def init(_) do
-    state =
-      if message_extractor_available?() do
-        {:ok, _messages} = MessagesExtractor.call()
+  def init(opts) do
+    conf = Keyword.fetch!(opts, :conf)
 
-        # Detect stale translations system-wide with fuzzy matching
-        {:ok, %StaleDetection.Result{} = result} = StaleDetection.call()
+    if conf.disable_stale_detection do
+      {:ok, %{stale_detection_result: nil}}
+    else
+      {:ok, init_stale_detection()}
+    end
+  end
 
-        %{stale_detection_result: result}
-      else
-        %{stale_detection_result: nil}
-      end
+  defp init_stale_detection do
+    if message_extractor_available?() do
+      {:ok, _messages} = MessagesExtractor.call()
 
-    {:ok, state}
+      # Detect stale translations system-wide with fuzzy matching
+      {:ok, %StaleDetection.Result{} = result} = StaleDetection.call()
+
+      %{stale_detection_result: result}
+    else
+      %{stale_detection_result: nil}
+    end
   end
 
   @doc """
@@ -51,9 +58,12 @@ defmodule Kanta.PoFiles.MessagesExtractorAgent do
   end
 
   def handle_call({:get_stale_detection_result, true}, _from, state) do
-    {:ok, %StaleDetection.Result{} = result} = StaleDetection.call()
-
-    {:reply, result, %{state | stale_detection_result: result}}
+    if Kanta.config().disable_stale_detection do
+      {:reply, state.stale_detection_result, state}
+    else
+      {:ok, %StaleDetection.Result{} = result} = StaleDetection.call()
+      {:reply, result, %{state | stale_detection_result: result}}
+    end
   end
 
   defp message_extractor_available? do

--- a/lib/kanta_web/live/dashboard/dashboard_live/dashboard_live.ex
+++ b/lib/kanta_web/live/dashboard/dashboard_live/dashboard_live.ex
@@ -35,33 +35,41 @@ defmodule KantaWeb.Dashboard.DashboardLive do
   end
 
   def handle_event("delete-stale", _, socket) do
-    %Result{stale_message_ids: stale_message_ids} =
-      MessagesExtractorAgent.get_stale_detection_result()
+    if Kanta.config().disable_stale_detection do
+      {:noreply, socket}
+    else
+      %Result{stale_message_ids: stale_message_ids} =
+        MessagesExtractorAgent.get_stale_detection_result()
 
-    Translations.delete_messages(MapSet.to_list(stale_message_ids))
+      Translations.delete_messages(MapSet.to_list(stale_message_ids))
 
-    stale_messages_count =
-      MessagesExtractorAgent.get_stale_detection_result(true).stale_count
+      stale_messages_count =
+        MessagesExtractorAgent.get_stale_detection_result(true).stale_count
 
-    {:noreply, assign(socket, :stale_messages_count, stale_messages_count)}
+      {:noreply, assign(socket, :stale_messages_count, stale_messages_count)}
+    end
   end
 
   # Merge all the orphaned messages to selected target messages (that fuzzy mathed).
   def handle_event("restore-mergeable", _, socket) do
-    %Result{fuzzy_matches_map: fuzzy_matches_map} =
-      MessagesExtractorAgent.get_stale_detection_result()
+    if Kanta.config().disable_stale_detection do
+      {:noreply, socket}
+    else
+      %Result{fuzzy_matches_map: fuzzy_matches_map} =
+        MessagesExtractorAgent.get_stale_detection_result()
 
-    # Merge all messages with fuzzy matches
-    Enum.each(fuzzy_matches_map, fn {_stale_id, fuzzy_match} ->
-      Translations.merge_messages(fuzzy_match.stale_message_id, fuzzy_match.matched_message_id)
-    end)
+      # Merge all messages with fuzzy matches
+      Enum.each(fuzzy_matches_map, fn {_stale_id, fuzzy_match} ->
+        Translations.merge_messages(fuzzy_match.stale_message_id, fuzzy_match.matched_message_id)
+      end)
 
-    result = MessagesExtractorAgent.get_stale_detection_result(true)
+      result = MessagesExtractorAgent.get_stale_detection_result(true)
 
-    {:noreply,
-     socket
-     |> assign(:mergeable_messages_count, result.mergeable_count)
-     |> assign(:stale_messages_count, result.stale_count)}
+      {:noreply,
+       socket
+       |> assign(:mergeable_messages_count, result.mergeable_count)
+       |> assign(:stale_messages_count, result.stale_count)}
+    end
   end
 
   def translation_progress(language) do
@@ -69,16 +77,24 @@ defmodule KantaWeb.Dashboard.DashboardLive do
   end
 
   defp get_stale_messages_count do
-    %Result{stale_count: stale_count} =
-      MessagesExtractorAgent.get_stale_detection_result()
-
-    stale_count
+    if Kanta.config().disable_stale_detection do
+      0
+    else
+      case MessagesExtractorAgent.get_stale_detection_result() do
+        nil -> 0
+        %Result{stale_count: stale_count} -> stale_count
+      end
+    end
   end
 
   defp get_mergeable_messages_count do
-    %Result{mergeable_count: mergeable_count} =
-      MessagesExtractorAgent.get_stale_detection_result()
-
-    mergeable_count
+    if Kanta.config().disable_stale_detection do
+      0
+    else
+      case MessagesExtractorAgent.get_stale_detection_result() do
+        nil -> 0
+        %Result{mergeable_count: mergeable_count} -> mergeable_count
+      end
+    end
   end
 end

--- a/lib/kanta_web/live/translations/translations_live/translations_live.ex
+++ b/lib/kanta_web/live/translations/translations_live/translations_live.ex
@@ -21,15 +21,13 @@ defmodule KantaWeb.Translations.TranslationsLive do
     socket =
       case get_locale(locale_id) do
         {:ok, locale} ->
-          # Get system-wide stale detection with fuzzy matching
-          {:ok, stale_result} =
-            Kanta.PoFiles.Services.StaleDetection.call()
+          {stale_message_ids, fuzzy_matches} = stale_detection_assigns()
 
           socket
           |> assign(:locale, locale)
           |> assign(:application_sources_empty?, Translations.application_sources_empty?())
-          |> assign(:stale_message_ids, stale_result.stale_message_ids)
-          |> assign(:fuzzy_matches, stale_result.fuzzy_matches_map)
+          |> assign(:stale_message_ids, stale_message_ids)
+          |> assign(:fuzzy_matches, fuzzy_matches)
           |> assign(get_assigns_from_params(params))
 
         _ ->
@@ -38,6 +36,17 @@ defmodule KantaWeb.Translations.TranslationsLive do
       end
 
     {:ok, socket}
+  end
+
+  defp stale_detection_assigns do
+    if Kanta.config().disable_stale_detection do
+      {MapSet.new(), %{}}
+    else
+      case MessagesExtractorAgent.get_stale_detection_result() do
+        nil -> {MapSet.new(), %{}}
+        %Result{stale_message_ids: ids, fuzzy_matches_map: fuzzy} -> {ids, fuzzy}
+      end
+    end
   end
 
   def handle_params(%{"locale_id" => locale_id} = params, _location, socket) do
@@ -118,9 +127,15 @@ defmodule KantaWeb.Translations.TranslationsLive do
   def handle_info(:refresh_messages, socket) do
     locale_id = socket.assigns.locale.id
 
-    # Re-detect system-wide stale messages with fuzzy matching
-    %Result{stale_message_ids: stale_message_ids, fuzzy_matches_map: fuzzy_matches_map} =
-      MessagesExtractorAgent.get_stale_detection_result(true)
+    {stale_message_ids, fuzzy_matches_map} =
+      if Kanta.config().disable_stale_detection do
+        {socket.assigns.stale_message_ids, socket.assigns.fuzzy_matches}
+      else
+        case MessagesExtractorAgent.get_stale_detection_result(true) do
+          nil -> {MapSet.new(), %{}}
+          %Result{stale_message_ids: ids, fuzzy_matches_map: fuzzy} -> {ids, fuzzy}
+        end
+      end
 
     # Re-fetch messages with current filters
     preload_filters = %{"locale_id" => locale_id}

--- a/test/kanta/po_files/messages_extractor_agent_test.exs
+++ b/test/kanta/po_files/messages_extractor_agent_test.exs
@@ -1,0 +1,71 @@
+defmodule Kanta.PoFiles.MessagesExtractorAgentTest do
+  use Kanta.Test.DataCase, async: false
+
+  alias Kanta.Config
+  alias Kanta.PoFiles.MessagesExtractorAgent
+  alias Kanta.PoFiles.Services.StaleDetection
+
+  describe "init/1" do
+    test "skips stale detection when disable_stale_detection is true" do
+      conf = Config.new(repo: Kanta.Test.Repo, disable_stale_detection: true)
+
+      # Mirrors the real shape the supervisor passes in (`conf.ex` in `lib/kanta.ex`):
+      # `{MessagesExtractorAgent, conf: conf, name: Registry.via(...)}`, i.e. a keyword
+      # list with more than just `:conf`. A regression test for the bug where `init/1`
+      # only matched a 1-key list and silently ignored `disable_stale_detection`.
+      assert {:ok, %{stale_detection_result: nil}} =
+               MessagesExtractorAgent.init(conf: conf, name: :some_registered_name)
+    end
+
+    test "runs stale detection when disable_stale_detection is false" do
+      conf = Config.new(repo: Kanta.Test.Repo, disable_stale_detection: false)
+
+      assert {:ok, %{stale_detection_result: %StaleDetection.Result{}}} =
+               MessagesExtractorAgent.init(conf: conf, name: :some_registered_name)
+    end
+  end
+
+  describe "handle_call/3 - {:get_stale_detection_result, false}" do
+    test "returns the cached result from state without recalculating" do
+      cached_result = %StaleDetection.Result{
+        stale_message_ids: MapSet.new([1, 2]),
+        fuzzy_matches_map: %{},
+        stale_count: 2,
+        mergeable_count: 0
+      }
+
+      state = %{stale_detection_result: cached_result}
+
+      assert {:reply, ^cached_result, ^state} =
+               MessagesExtractorAgent.handle_call(
+                 {:get_stale_detection_result, false},
+                 {self(), make_ref()},
+                 state
+               )
+    end
+  end
+
+  describe "handle_call/3 - {:get_stale_detection_result, true}" do
+    # NOTE: this only exercises the branch taken when the *global* `disable_stale_detection`
+    # config is `false` (the value the test suite boots with in test_helper.exs). The
+    # `disable_stale_detection: true` branch reads `Kanta.config().disable_stale_detection`
+    # directly instead of from this GenServer's own state, so it can't be exercised here
+    # without either mutating the live, suite-wide `Kanta` registry entry (unsafe — it's
+    # shared by every other test) or booting a second named `Kanta` instance (not possible
+    # today: `MessagesExtractorAgent.start_link/1` always registers under the literal name
+    # `MessagesExtractorAgent`, so a second instance collides with `{:already_started, pid}`
+    # on the first one started in test_helper.exs).
+    test "recalculates stale detection when disable_stale_detection is false (current global config)" do
+      state = %{stale_detection_result: nil}
+
+      assert {:reply, %StaleDetection.Result{} = result, new_state} =
+               MessagesExtractorAgent.handle_call(
+                 {:get_stale_detection_result, true},
+                 {self(), make_ref()},
+                 state
+               )
+
+      assert new_state.stale_detection_result == result
+    end
+  end
+end


### PR DESCRIPTION
## What this does

Fixes a bug in the `disable_stale_detection` implementation (related to
upstream PR #139 / issue #55): the flag had no effect on
`MessagesExtractorAgent` startup, because `init/1` used a pattern match
(`conf: %Kanta.Config{...}`) that only matches a keyword list of exactly
one element, while the process is started with a 2-key list
(`[conf: conf, name: ...]`). As a result, even with
`disable_stale_detection: true` configured, the app kept running
`MessagesExtractor.call()` + `StaleDetection.call()` synchronously on every
startup — exactly the expensive work the flag was meant to skip.

## Changes

- `lib/kanta/config.ex` — adds the `disable_stale_detection` field (type +
  validation).
- `lib/kanta/po_files/messages_extractor_agent.ex` — `init/1` fixed using
  `Keyword.fetch!(opts, :conf)`; `handle_call` guarded to skip
  recalculation when the flag is enabled.
- `lib/kanta_web/live/dashboard/dashboard_live/dashboard_live.ex` and
  `translations_live.ex` — short-circuit to empty values when the flag is
  enabled, and handle a `nil` result (previously this could crash if the
  agent hadn't run detection yet).
- `test/kanta/po_files/messages_extractor_agent_test.exs` (new) — 4 tests:
  2 cover the `init/1` bug directly (verified to fail when the fix is
  reverted), 2 cover `handle_call/3`.

## Known test-coverage limitation

The LiveView guards and the `disable_stale_detection: true` branch of
`handle_call` are not covered by tests, because they depend on
`Kanta.config()` — the configuration of the single global `Kanta` instance
started once in `test_helper.exs` — and there is no safe way to mutate it
or to start a second instance for those cases without also touching
`MessagesExtractorAgent`'s multi-instance support (it currently always
registers under a fixed name).

## How to verify

```
mix test test/kanta/po_files/messages_extractor_agent_test.exs
mix test
mix format --check-formatted
MIX_ENV=test mix credo
mix dialyzer -Wno_match --format short
```