### PR TITLE
fix: generate_locale_gradient/1 crashes when a locale has no colors

### DIFF
--- a/lib/kanta_web/live/translations/locales_live/locales_live.ex
+++ b/lib/kanta_web/live/translations/locales_live/locales_live.ex
@@ -2,6 +2,7 @@ defmodule KantaWeb.Translations.LocalesLive do
   use KantaWeb, :live_view
 
   alias Kanta.Translations
+  alias Kanta.Utils.Colors
 
   def mount(_params, _session, socket) do
     %{entries: locales, metadata: _entries_metadata} = Translations.list_locales()
@@ -12,15 +13,20 @@ defmodule KantaWeb.Translations.LocalesLive do
   end
 
   def generate_locale_gradient(locale) do
-    case length(locale.colors) do
+    colors = locale.colors || []
+
+    case length(colors) do
+      0 ->
+        "background: #{Colors.default_color()};"
+
       1 ->
-        "background: #{List.first(locale.colors)};"
+        "background: #{List.first(colors)};"
 
       2 ->
-        "background: #{List.first(locale.colors)}; background: linear-gradient(145deg, #{Enum.at(locale.colors, 0)} 45%, #{Enum.at(locale.colors, 1)} 50% 100%);"
+        "background: #{List.first(colors)}; background: linear-gradient(145deg, #{Enum.at(colors, 0)} 45%, #{Enum.at(colors, 1)} 50% 100%);"
 
-      3 ->
-        "background: #{List.first(locale.colors)}; background: linear-gradient(145deg, #{Enum.at(locale.colors, 0)} 0% 30%, #{Enum.at(locale.colors, 1)} 33% 66%, #{Enum.at(locale.colors, 2)} 66% 100%);"
+      _ ->
+        "background: #{List.first(colors)}; background: linear-gradient(145deg, #{Enum.at(colors, 0)} 0% 30%, #{Enum.at(colors, 1)} 33% 66%, #{Enum.at(colors, 2)} 66% 100%);"
     end
   end
 end

--- a/test/kanta_web/live/translations/locales_live_test.exs
+++ b/test/kanta_web/live/translations/locales_live_test.exs
@@ -1,0 +1,40 @@
+defmodule KantaWeb.Translations.LocalesLiveTest do
+  use ExUnit.Case, async: true
+
+  alias KantaWeb.Translations.LocalesLive
+
+  describe "generate_locale_gradient/1" do
+    test "falls back to the default color when colors is nil" do
+      assert LocalesLive.generate_locale_gradient(%{colors: nil}) ==
+               "background: #{Kanta.Utils.Colors.default_color()};"
+    end
+
+    test "falls back to the default color when colors is empty" do
+      assert LocalesLive.generate_locale_gradient(%{colors: []}) ==
+               "background: #{Kanta.Utils.Colors.default_color()};"
+    end
+
+    test "returns a flat background for a single color" do
+      assert LocalesLive.generate_locale_gradient(%{colors: ["#123456"]}) ==
+               "background: #123456;"
+    end
+
+    test "returns a two-color gradient" do
+      css = LocalesLive.generate_locale_gradient(%{colors: ["#111111", "#222222"]})
+
+      assert css =~ "linear-gradient"
+      assert css =~ "#111111"
+      assert css =~ "#222222"
+    end
+
+    test "returns a three-color gradient" do
+      css =
+        LocalesLive.generate_locale_gradient(%{colors: ["#111111", "#222222", "#333333"]})
+
+      assert css =~ "linear-gradient"
+      assert css =~ "#111111"
+      assert css =~ "#222222"
+      assert css =~ "#333333"
+    end
+  end
+end


### PR DESCRIPTION
## What this does

`KantaWeb.Translations.LocalesLive.generate_locale_gradient/1` calls
`length(locale.colors)` and then matches on `1`/`2`/`3`. Two real
states weren't handled:

- `colors: nil` — the field is optional with no default in the schema,
  so `length(nil)` raises `ArgumentError`.
- `colors: []` — no case clause matches `0`, raising `CaseClauseError`.

Both are easy to hit: any locale created without an explicit colors
list crashes the Locales page.

## Fix

Normalizes `colors` to `[]` up front and falls back to
`Kanta.Utils.Colors.default_color/0` (already used elsewhere in the
codebase, e.g. `ApplicationSource`'s default color) for the 0-color
case.

## How to verify

```
mix test test/kanta_web/live/translations/locales_live_test.exs
mix test
mix format --check-formatted
MIX_ENV=test mix credo
mix dialyzer -Wno_match --format short
```