### PR TITLE
fix: GET /kanta-api/messages returns 500 whenever a message exists

### DIFF
--- a/lib/kanta_web/controllers/api/messages_controller.ex
+++ b/lib/kanta_web/controllers/api/messages_controller.ex
@@ -7,12 +7,14 @@ defmodule KantaWeb.Api.MessagesController do
   alias Kanta.Translations.Messages.Finders.ListMessages
   alias Kanta.Utils.DatabasePopulator
 
+  @preloads [:domain, :context, :singular_translations, :plural_translations]
+
   def index(conn, params) do
     page = params |> Map.get("page", "1") |> String.to_integer()
 
     conn
     |> put_status(200)
-    |> json(ListMessages.find(page: page))
+    |> json(ListMessages.find(page: page, preloads: @preloads))
   end
 
   def update(conn, %{"entries" => entries}) do

--- a/test/kanta/translations/messages/list_messages_json_encoding_test.exs
+++ b/test/kanta/translations/messages/list_messages_json_encoding_test.exs
@@ -1,0 +1,48 @@
+defmodule Kanta.Translations.Messages.Finders.ListMessagesJsonEncodingTest do
+  use Kanta.Test.DataCase, async: false
+
+  alias Kanta.Translations
+  alias Kanta.Translations.Messages.Finders.ListMessages
+
+  # Message's `@derive Jason.Encoder` includes :domain, :context,
+  # :singular_translations and :plural_translations. Encoding a message
+  # whose associations weren't preloaded raises, because
+  # %Ecto.Association.NotLoaded{} isn't JSON-encodable. This mirrors what
+  # KantaWeb.Api.MessagesController.index/2 does with the result of
+  # ListMessages.find/1.
+  describe "encoding the result of ListMessages.find/1" do
+    setup do
+      {:ok, domain} = Translations.create_domain(%{name: "default"})
+      {:ok, context} = Translations.create_context(%{name: "ui"})
+
+      {:ok, message} =
+        Translations.create_message(%{
+          msgid: "Hello world",
+          message_type: :singular,
+          domain_id: domain.id,
+          context_id: context.id
+        })
+
+      %{message: message}
+    end
+
+    test "raises when the associations aren't preloaded", %{message: _message} do
+      result = ListMessages.find(page: 1)
+
+      assert_raise RuntimeError, ~r/association :domain .* was not loaded/, fn ->
+        Jason.encode!(result)
+      end
+    end
+
+    test "succeeds when domain/context/translations are preloaded", %{message: message} do
+      result =
+        ListMessages.find(
+          page: 1,
+          preloads: [:domain, :context, :singular_translations, :plural_translations]
+        )
+
+      assert {:ok, json} = Jason.encode(result)
+      assert json =~ message.msgid
+    end
+  end
+end


### PR DESCRIPTION
## What this does

`KantaWeb.Api.MessagesController.index/2` calls
`ListMessages.find(page: page)` with no `:preloads`. `Message`'s
`@derive {Jason.Encoder, ...}` includes `:domain`, `:context`,
`:singular_translations` and `:plural_translations` — encoding a
message whose associations weren't preloaded raises, since
`%Ecto.Association.NotLoaded{}` isn't JSON-encodable.

In practice: `GET /kanta-api/messages` returns 500 as soon as the
database has at least one message. The empty-list case is the only
one that currently works.

## Fix

Passes `preloads: [:domain, :context, :singular_translations, :plural_translations]`
to `ListMessages.find/1`, matching what the derived encoder needs.

## How to verify

```
mix test test/kanta/translations/messages/list_messages_json_encoding_test.exs
mix test
mix format --check-formatted
MIX_ENV=test mix credo
mix dialyzer -Wno_match --format short
```

The added test also documents the underlying issue directly: calling
`ListMessages.find/1` without preloads and JSON-encoding the result
still raises, since the finder itself has no default preloads — the
fix here is scoped to the controller matching what it actually needs
to encode.